### PR TITLE
Removed first stack trace and added 4 methods, #getClassName, etc.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,6 @@
 # Module status
 version = 0.1.0
 copyright = Copyright (C) 2021 Takayuki Sato
-value = MIT License
 
 # Directories
 dir.bin=${basedir}/bin

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -5,11 +5,15 @@
   Copyright (C) 2021 Takayuki Sato All Rights Reserved.
 -->
 <ivysettings>
-  <settings defaultResolver="central"/>
+  <settings defaultResolver="default"/>
   <resolvers>
     <ibiblio name="central" m2compatible="true"/>
     <filesystem name="local" m2compatible="true" checksums="md5,sha1">
-     <artifact pattern="${dir.repo}/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
+      <artifact pattern="${dir.repo}/[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
     </filesystem>
+    <chain name="default" returnFirst="true">
+      <resolver ref="local"/>
+      <resolver ref="central"/>
+    </chain>
   </resolvers>
 </ivysettings>

--- a/src/sttk/reasonederror/ReasonedException.java
+++ b/src/sttk/reasonederror/ReasonedException.java
@@ -4,6 +4,7 @@
  */
 package sttk.reasonederror;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -50,6 +51,9 @@ public final class ReasonedException extends Exception {
   /** The map for error situation parameters. */
   private final Map<String, Object> situation;
 
+  /** The stack trace for the location of occurrence. */
+  private final StackTraceElement trace;
+
 
   /**
    * The constructor which takes a reason of this exception as an argument.
@@ -63,6 +67,11 @@ public final class ReasonedException extends Exception {
       final Map<String, Object> map) {
     this.reason = reason;
     this.situation = map;
+
+    var traces = getStackTrace();
+    setStackTrace(Arrays.copyOfRange(traces, 1, traces.length));
+
+    this.trace = traces[1];
   }
 
 
@@ -81,6 +90,11 @@ public final class ReasonedException extends Exception {
     super(cause);
     this.reason = reason;
     this.situation = map;
+
+    var traces = getStackTrace();
+    setStackTrace(Arrays.copyOfRange(traces, 1, traces.length));
+
+    this.trace = traces[1];
   }
 
 
@@ -152,6 +166,46 @@ public final class ReasonedException extends Exception {
     }
 
     return buf.toString();
+  }
+
+
+  /**
+   * Returns the fully qualified name of the class of this error occurrence.
+   *
+   * @return  The fully qualified name of the class of this error occurerce.
+   */
+  public String getClassName() {
+    return trace.getClassName();
+  }
+
+
+  /**
+   * Returns the name of the method of this error occurrence.
+   *
+   * @return  The name of the method of this error occurrence.
+   */
+  public String getMethodName() {
+    return trace.getMethodName();
+  }
+
+
+  /**
+   * Returns the name of the source file of this error occurrence.
+   *
+   * @return  The name of the source file of this error occurrence.
+   */
+  public String getFileName() {
+    return trace.getFileName();
+  }
+
+
+  /**
+   * Returns the line number of the source file of this error occurrence.
+   *
+   * @return  The line number of the source file of this error occurrence.
+   */
+  public int getLineNumber() {
+    return trace.getLineNumber();
   }
 
 

--- a/src/sttk/reasonederror/ReasonedExceptionTest.java
+++ b/src/sttk/reasonederror/ReasonedExceptionTest.java
@@ -31,6 +31,12 @@ public class ReasonedExceptionTest {
       assertThat(re.getCause()).isNull();
       assertThat(re.getMessage()).isEqualTo(
         "reason=FailToDoSomething");
+      assertThat(re.getClassName()).isEqualTo(
+        "sttk.reasonederror.ReasonedExceptionTest");
+      assertThat(re.getMethodName()).isEqualTo(
+        "should_create_and_throw_an_exception_with_a_reason");
+      assertThat(re.getFileName()).isEqualTo("ReasonedExceptionTest.java");
+      assertThat(re.getLineNumber()).isEqualTo(27);
     }
   }
 
@@ -47,6 +53,12 @@ public class ReasonedExceptionTest {
       assertThat(re.getMessage()).isEqualTo(
         "reason=FailToDoSomething, " +
         "cause=java.io.IOException: Message");
+      assertThat(re.getClassName()).isEqualTo(
+        "sttk.reasonederror.ReasonedExceptionTest");
+      assertThat(re.getMethodName()).isEqualTo(
+        "should_create_and_throw_an_exception_with_a_reason_and_a_cause");
+      assertThat(re.getFileName()).isEqualTo("ReasonedExceptionTest.java");
+      assertThat(re.getLineNumber()).isEqualTo(48);
     }
   }
 
@@ -73,6 +85,12 @@ public class ReasonedExceptionTest {
       assertThat(re.getMessage()).isEqualTo(
         "reason=FailToDoSomething, " +
         "name1=value1, name2=1234");
+      assertThat(re.getClassName()).isEqualTo(
+        "sttk.reasonederror.ReasonedExceptionTest");
+      assertThat(re.getMethodName()).isEqualTo(
+        "should_create_and_throw_an_exception_with_a_reason_and_situation_parameters");
+      assertThat(re.getFileName()).isEqualTo("ReasonedExceptionTest.java");
+      assertThat(re.getLineNumber()).isEqualTo(72);
     }
   }
 
@@ -101,8 +119,15 @@ public class ReasonedExceptionTest {
         "reason=FailToDoSomething, " +
         "name1=value1, name2=1234, " +
         "cause=java.io.IOException: Message");
+      assertThat(re.getClassName()).isEqualTo(
+        "sttk.reasonederror.ReasonedExceptionTest");
+      assertThat(re.getMethodName()).isEqualTo(
+        "should_create_and_throw_an_exception_with_a_reason_and_a_cause_and_situation_parameters");
+      assertThat(re.getFileName()).isEqualTo("ReasonedExceptionTest.java");
+      assertThat(re.getLineNumber()).isEqualTo(105);
     }
   }
+
 
   @Test
   public void should_print_message_when_cause_is_a_ReasonedException() {
@@ -136,6 +161,12 @@ public class ReasonedExceptionTest {
           "reason=InvalidState, " +
           "aaa=bbb, " +
           "cause=java.io.IOException: Message");
+        assertThat(re.getClassName()).isEqualTo(
+          "sttk.reasonederror.ReasonedExceptionTest");
+        assertThat(re.getMethodName()).isEqualTo(
+          "should_print_message_when_cause_is_a_ReasonedException");
+        assertThat(re.getFileName()).isEqualTo("ReasonedExceptionTest.java");
+        assertThat(re.getLineNumber()).isEqualTo(144);
       }
     }
   }


### PR DESCRIPTION
### Changes by this PR

1. Removed first stack trace because first stack trace is what of `By` method in `ReasonedException` and unnecessary.
2. Added four methods, `#getClassName`, `#getMethodName`, `#getFileName`, `#getLineNumber`.